### PR TITLE
Revert "Bump gunicorn from 21.2.0 to 23.0.0"

### DIFF
--- a/requirements-cloud.txt
+++ b/requirements-cloud.txt
@@ -44,4 +44,4 @@ scipy==1.11.4
 psutil==5.9.6
 
 # Web server
-gunicorn==23.0.0
+gunicorn==21.2.0


### PR DESCRIPTION
### **User description**
Reverts Mouy-leng/GenX_FX#180


___

### **PR Type**
Other


___

### **Description**
- Revert gunicorn version from 23.0.0 to 21.2.0


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gunicorn 23.0.0"] -- "revert" --> B["gunicorn 21.2.0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements-cloud.txt</strong><dd><code>Revert gunicorn version downgrade</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements-cloud.txt

- Downgrade gunicorn dependency from version 23.0.0 to 21.2.0


</details>


  </td>
  <td><a href="https://github.com/Mouy-leng/GenX_FX/pull/193/files#diff-38376add0af1a2baf41aa4f5ff9dfea3c8e39e7e50e683e57e3834852f479219">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

